### PR TITLE
Port to 1.20.1 and support block entities

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 TheEpicBlock & ThatCreeper
+Copyright (c) 2021 TheEpicBlock
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the \"Software\"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 TheEpicBlock
+Copyright (c) 2021 TheEpicBlock & ThatCreeper
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the \"Software\"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# Immersive Cursedness
+# Immersive Cursedness Updated Fork
+
+This is an updated fork of TheEpicBlock's Immersive Cursedness.
+
+Warning: This was only lightly tested on 1.20.1. There may be bugs.
+
+Also, it supports block entities.
+
+Woo-hoo!
+
+---
 
 Have you ever used Immersive Portals and thought *this isn't cursed enough*? Then this mod is for you!
 It uses advanced cursedness to deliver immersiveness straight to the client. And uses intelligent packet spam to ensure clients don't even have to install the mod themselves!

--- a/README.md
+++ b/README.md
@@ -1,14 +1,4 @@
-# Immersive Cursedness Updated Fork
-
-This is an updated fork of TheEpicBlock's Immersive Cursedness.
-
-Warning: This was only lightly tested on 1.20.1. There may be bugs.
-
-Also, it supports block entities.
-
-Woo-hoo!
-
----
+# Immersive Cursedness
 
 Have you ever used Immersive Portals and thought *this isn't cursed enough*? Then this mod is for you!
 It uses advanced cursedness to deliver immersiveness straight to the client. And uses intelligent packet spam to ensure clients don't even have to install the mod themselves!

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,18 @@
 plugins {
 	id "com.modrinth.minotaur" version "1.2.1"
-	id 'fabric-loom' version '0.12-SNAPSHOT'
+	id 'fabric-loom' version '1.10-SNAPSHOT'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_21
+targetCompatibility = JavaVersion.VERSION_21
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
 repositories {
-	jcenter()
+	maven { url "https://maven.shedaniel.me/" }
 }
 
 dependencies {
@@ -24,10 +24,7 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modApi("me.sargunvohra.mcmods:autoconfig1u:${project.autoconfig_version}") {
-		exclude(group: "net.fabricmc.fabric-api")
-	}
-	include "me.sargunvohra.mcmods:autoconfig1u:${project.autoconfig_version}"
+	modApi "me.shedaniel.cloth:cloth-config-fabric:17.0.144"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.20.1
-	yarn_mappings=1.20.1+build.10
-	loader_version=0.14.22
+	minecraft_version=1.21.4
+	yarn_mappings=1.21.4+build.8
+	loader_version=0.16.12
 
 # Mod Properties
-	mod_version = 1.5.0
+	mod_version = 1.5.1
 	maven_group = nl.theepicblock
 	archives_base_name = immersive-cursedness
 
@@ -16,5 +16,4 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.88.1+1.20.1
-	autoconfig_version=3.3.1
+	fabric_version=0.119.2+1.21.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.19
-	yarn_mappings=1.19+build.2
-	loader_version=0.14.7
+	minecraft_version=1.20
+	yarn_mappings=1.20+build.1
+	loader_version=0.14.21
 
 # Mod Properties
 	mod_version = 1.4.7
@@ -16,5 +16,5 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.55.3+1.19
+	fabric_version=0.83.0+1.20
 	autoconfig_version=3.3.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,18 +3,18 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.20
-	yarn_mappings=1.20+build.1
-	loader_version=0.14.21
+	minecraft_version=1.20.1
+	yarn_mappings=1.20.1+build.10
+	loader_version=0.14.22
 
 # Mod Properties
-	mod_version = 1.4.7
+	mod_version = 1.5.0
 	maven_group = nl.theepicblock
 	archives_base_name = immersive-cursedness
 
-	modrinth_project = lyiXgXNm
+	modrinth_project = aCkoEaRG
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.83.0+1.20
+	fabric_version=0.88.1+1.20.1
 	autoconfig_version=3.3.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/nl/theepicblock/immersive_cursedness/Config.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/Config.java
@@ -1,10 +1,10 @@
 package nl.theepicblock.immersive_cursedness;
 
-import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
-import me.sargunvohra.mcmods.autoconfig1u.shadowed.blue.endless.jankson.Comment;
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.Comment;
 
 @SuppressWarnings("FieldMayBeFinal")
-@me.sargunvohra.mcmods.autoconfig1u.annotation.Config(name = "immersive-cursedness")
+@me.shedaniel.autoconfig.annotation.Config(name = "immersive-cursedness")
 public class Config implements ConfigData {
 	public int horizontalSendLimit = 70;
 	@Comment("Should usually be atmosphereRadius+2")

--- a/src/main/java/nl/theepicblock/immersive_cursedness/CursednessServer.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/CursednessServer.java
@@ -1,9 +1,8 @@
 package nl.theepicblock.immersive_cursedness;
 
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfig;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
-import org.apache.logging.log4j.Logger;
 
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
@@ -61,9 +60,7 @@ public class CursednessServer {
         }
 
         //Tick player managers
-        playerManagers.forEach((player, manager) -> {
-            manager.tick(tickCount);
-        });
+        playerManagers.forEach((player, manager) -> manager.tick(tickCount));
     }
 
     public PlayerManager getManager(ServerPlayerEntity player) {

--- a/src/main/java/nl/theepicblock/immersive_cursedness/ImmersiveCursedness.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/ImmersiveCursedness.java
@@ -1,13 +1,12 @@
 package nl.theepicblock.immersive_cursedness;
 
 import com.mojang.brigadier.Command;
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
-import me.sargunvohra.mcmods.autoconfig1u.serializer.JanksonConfigSerializer;
+import me.shedaniel.autoconfig.AutoConfig;
+import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.minecraft.server.command.CommandManager;
-import net.minecraft.text.Text;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -28,21 +27,17 @@ public class ImmersiveCursedness implements ModInitializer {
             cursednessThread.start();
             cursednessThread.setName("Immersive Cursedness Thread");
         });
-        ServerLifecycleEvents.SERVER_STOPPED.register(minecraftServer -> {
-            cursednessServer.stop();
-        });
+        ServerLifecycleEvents.SERVER_STOPPED.register(minecraftServer -> cursednessServer.stop());
 
-        CommandRegistrationCallback.EVENT.register((dispatcher, b, c) -> {
-            dispatcher.register(CommandManager.literal("portal")
-                    .then(CommandManager.literal("toggle").executes((context) -> {
-                        PlayerInterface pi = (PlayerInterface)context.getSource().getPlayer();
-                        pi.immersivecursedness$setEnabled(!pi.immersivecursedness$getEnabled());
-                        //context.getSource().sendFeedback(Text.literal("you have now "+ (pi.immersivecursedness$getEnabled() ? "enabled" : "disabled") +" immersive portals"), false);
-                        if (pi.immersivecursedness$getEnabled() == false) {
-                            Util.getManagerFromPlayer(context.getSource().getPlayer()).purgeCache();
-                        }
-                        return Command.SINGLE_SUCCESS;
-                    })));
-        });
+        CommandRegistrationCallback.EVENT.register((dispatcher, b, c) -> dispatcher.register(CommandManager.literal("portal")
+                .then(CommandManager.literal("toggle").executes((context) -> {
+                    PlayerInterface pi = (PlayerInterface)context.getSource().getPlayer();
+                    pi.immersivecursedness$setEnabled(!pi.immersivecursedness$getEnabled());
+                    //context.getSource().sendFeedback(Text.literal("you have now "+ (pi.immersivecursedness$getEnabled() ? "enabled" : "disabled") +" immersive portals"), false);
+                    if (!pi.immersivecursedness$getEnabled()) {
+                        Util.getManagerFromPlayer(context.getSource().getPlayer()).purgeCache();
+                    }
+                    return Command.SINGLE_SUCCESS;
+                }))));
     }
 }

--- a/src/main/java/nl/theepicblock/immersive_cursedness/ImmersiveCursedness.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/ImmersiveCursedness.java
@@ -37,7 +37,7 @@ public class ImmersiveCursedness implements ModInitializer {
                     .then(CommandManager.literal("toggle").executes((context) -> {
                         PlayerInterface pi = (PlayerInterface)context.getSource().getPlayer();
                         pi.immersivecursedness$setEnabled(!pi.immersivecursedness$getEnabled());
-                        context.getSource().sendFeedback(Text.literal("you have now "+ (pi.immersivecursedness$getEnabled() ? "enabled" : "disabled") +" immersive portals"), false);
+                        //context.getSource().sendFeedback(Text.literal("you have now "+ (pi.immersivecursedness$getEnabled() ? "enabled" : "disabled") +" immersive portals"), false);
                         if (pi.immersivecursedness$getEnabled() == false) {
                             Util.getManagerFromPlayer(context.getSource().getPlayer()).purgeCache();
                         }

--- a/src/main/java/nl/theepicblock/immersive_cursedness/PortalManager.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/PortalManager.java
@@ -70,9 +70,7 @@ public class PortalManager {
                 Portal p = new Portal(upperRight, lowerLeft, axis, hasCorners, transformProfile);
                 newPortals.add(p);
 
-                BlockPos.iterate(upperRight,lowerLeft).forEach((pos) -> {
-                    checked.add(pos.toImmutable());
-                });
+                BlockPos.iterate(upperRight,lowerLeft).forEach((pos) -> checked.add(pos.toImmutable()));
             } catch (IllegalArgumentException ignored) {}
         }
         this.portals = newPortals;
@@ -111,7 +109,7 @@ public class PortalManager {
         DummyEntity dummyEntity = new DummyEntity(((PlayerInterface)player).immersivecursedness$getUnfakedWorld(), pos);
         dummyEntity.setBodyYaw(0);
         portalForcerMixinActivate = true;
-        TeleportTarget teleportTarget = dummyEntity.getTeleportTargetB(destination);
+	    TeleportTarget teleportTarget = dummyEntity.getTeleportTargetB(destination);
         portalForcerMixinActivate = false;
 
         if (teleportTarget == null) {
@@ -120,9 +118,9 @@ public class PortalManager {
 
         return new TransformProfile(
                 pos,
-                new BlockPos(MathHelper.floor(teleportTarget.position.x), MathHelper.floor(teleportTarget.position.y), MathHelper.floor(teleportTarget.position.z)),
+                new BlockPos(MathHelper.floor(teleportTarget.position().x), MathHelper.floor(teleportTarget.position().y), MathHelper.floor(teleportTarget.position().z)),
                 0,
-                (int)teleportTarget.yaw);
+                (int)teleportTarget.yaw());
     }
 
     private void garbageCollect(ServerPlayerEntity player) {
@@ -142,8 +140,6 @@ public class PortalManager {
     }
 
     private static Stream<PointOfInterest> getPortalsInChunkRadius(PointOfInterestStorage storage, BlockPos pos, int radius) {
-        return ChunkPos.stream(new ChunkPos(pos), radius).flatMap((chunkPos) -> {
-            return storage.getInChunk((poi) -> poi.matchesKey(PointOfInterestTypes.NETHER_PORTAL), chunkPos, PointOfInterestStorage.OccupationStatus.ANY);
-        });
+        return ChunkPos.stream(new ChunkPos(pos), radius).flatMap((chunkPos) -> storage.getInChunk((poi) -> poi.matchesKey(PointOfInterestTypes.NETHER_PORTAL), chunkPos, PointOfInterestStorage.OccupationStatus.ANY));
     }
 }

--- a/src/main/java/nl/theepicblock/immersive_cursedness/PortalManager.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/PortalManager.java
@@ -7,6 +7,7 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.TeleportTarget;
 import net.minecraft.world.poi.PointOfInterest;
 import net.minecraft.world.poi.PointOfInterestStorage;
@@ -119,7 +120,7 @@ public class PortalManager {
 
         return new TransformProfile(
                 pos,
-                new BlockPos(teleportTarget.position),
+                new BlockPos(MathHelper.floor(teleportTarget.position.x), MathHelper.floor(teleportTarget.position.y), MathHelper.floor(teleportTarget.position.z)),
                 0,
                 (int)teleportTarget.yaw);
     }

--- a/src/main/java/nl/theepicblock/immersive_cursedness/Util.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/Util.java
@@ -12,7 +12,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.*;
-import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.world.HeightLimitView;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
@@ -20,6 +20,7 @@ import net.minecraft.world.chunk.ChunkStatus;
 import net.minecraft.world.poi.PointOfInterest;
 import nl.theepicblock.immersive_cursedness.mixin.ServerChunkManagerInvoker;
 import nl.theepicblock.immersive_cursedness.objects.TransformProfile;
+import org.joml.Vector3f;
 
 import java.util.Optional;
 
@@ -98,7 +99,7 @@ public class Util {
     }
 
     public static void sendParticle(ServerPlayerEntity player, Vec3d pos, float r, float g, float b) {
-        player.networkHandler.sendPacket(new ParticleS2CPacket(new DustParticleEffect(new Vec3f(r,g,b),1), true, pos.x, pos.y, pos.z, 0, 0, 0, 0, 0));
+        player.networkHandler.sendPacket(new ParticleS2CPacket(new DustParticleEffect(new Vector3f(r,g,b),1), true, pos.x, pos.y, pos.z, 0, 0, 0, 0, 0));
     }
 
     public static BlockPos makeBlockPos(double x, double y, double z) {

--- a/src/main/java/nl/theepicblock/immersive_cursedness/mixin/EntityPositionS2CPacketAccessor.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/mixin/EntityPositionS2CPacketAccessor.java
@@ -1,14 +1,12 @@
 package nl.theepicblock.immersive_cursedness.mixin;
 
+import net.minecraft.entity.player.PlayerPosition;
 import net.minecraft.network.packet.s2c.play.EntityPositionS2CPacket;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(EntityPositionS2CPacket.class)
 public interface EntityPositionS2CPacketAccessor {
-    @Accessor("x")
-    void ic$setX(double v);
-
-    @Accessor("y")
-    void ic$setY(double v);
+    @Accessor("change")
+    void ic$setChange(PlayerPosition v);
 }

--- a/src/main/java/nl/theepicblock/immersive_cursedness/mixin/MixinPlayerEntity.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/mixin/MixinPlayerEntity.java
@@ -4,33 +4,13 @@ import com.mojang.authlib.GameProfile;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemStack;
-import net.minecraft.screen.PlayerScreenHandler;
-import net.minecraft.util.Uuids;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import java.util.Optional;
 
 @Mixin(PlayerEntity.class)
 public abstract class MixinPlayerEntity extends LivingEntity {
     public MixinPlayerEntity(World world, BlockPos pos, float yaw, GameProfile gameProfile) {
         super(EntityType.PLAYER, world);
-    }
-
-    /**
-     * @reason makes it so the portal always takes 1 tick to go through. Even when in survival
-     * @author TheEpicBlock_TEB
-     */
-    @Inject(method = "getMaxNetherPortalTime", at = @At("HEAD"), cancellable = true)
-    public void handleGetMaxNetherPortalTime(CallbackInfoReturnable<Integer> cir) {
-
     }
 }

--- a/src/main/java/nl/theepicblock/immersive_cursedness/mixin/MixinPlayerEntity.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/mixin/MixinPlayerEntity.java
@@ -1,17 +1,36 @@
 package nl.theepicblock.immersive_cursedness.mixin;
 
+import com.mojang.authlib.GameProfile;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.PlayerScreenHandler;
+import net.minecraft.util.Uuids;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Optional;
 
 @Mixin(PlayerEntity.class)
-public abstract class MixinPlayerEntity {
+public abstract class MixinPlayerEntity extends LivingEntity {
+    public MixinPlayerEntity(World world, BlockPos pos, float yaw, GameProfile gameProfile) {
+        super(EntityType.PLAYER, world);
+    }
+
     /**
      * @reason makes it so the portal always takes 1 tick to go through. Even when in survival
      * @author TheEpicBlock_TEB
      */
-    @Overwrite
-    public int getMaxNetherPortalTime() {
-        return 1;
+    @Inject(method = "getMaxNetherPortalTime", at = @At("HEAD"), cancellable = true)
+    public void handleGetMaxNetherPortalTime(CallbackInfoReturnable<Integer> cir) {
+
     }
 }

--- a/src/main/java/nl/theepicblock/immersive_cursedness/mixin/MixinServerPlayerEntity.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/mixin/MixinServerPlayerEntity.java
@@ -1,8 +1,7 @@
 package nl.theepicblock.immersive_cursedness.mixin;
 
 import com.mojang.authlib.GameProfile;
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
-import net.minecraft.entity.player.PlayerEntity;
+import me.shedaniel.autoconfig.AutoConfig;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.encryption.PlayerPublicKey;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -16,7 +15,6 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @SuppressWarnings("PointlessBooleanExpression")
 @Mixin(ServerPlayerEntity.class)
@@ -87,11 +85,5 @@ public abstract class MixinServerPlayerEntity extends MixinPlayerEntity implemen
 	@Override
 	public boolean immersivecursedness$getEnabled() {
 		return enabled;
-	}
-
-	@Override
-	public void handleGetMaxNetherPortalTime(CallbackInfoReturnable<Integer> cir) {
-		if (enabled)
-			cir.setReturnValue(1);
 	}
 }

--- a/src/main/java/nl/theepicblock/immersive_cursedness/mixin/MixinServerPlayerEntity.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/mixin/MixinServerPlayerEntity.java
@@ -16,17 +16,21 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @SuppressWarnings("PointlessBooleanExpression")
 @Mixin(ServerPlayerEntity.class)
-public abstract class MixinServerPlayerEntity extends PlayerEntity implements PlayerInterface {
+public abstract class MixinServerPlayerEntity extends MixinPlayerEntity implements PlayerInterface {
 	public MixinServerPlayerEntity(World world, BlockPos pos, float yaw, GameProfile profile, PlayerPublicKey publicKey) {
-		super(world, pos, yaw, profile, publicKey);
+		super(world, pos, yaw, profile);
 	}
 
-	@Unique private volatile boolean isCloseToPortal;
-	@Unique private World unFakedWorld;
-	@Unique private boolean enabled = true;
+	@Unique
+	private volatile boolean isCloseToPortal;
+	@Unique
+	private World unFakedWorld;
+	@Unique
+	private boolean enabled = true;
 
 	@Override
 	public void immersivecursedness$setCloseToPortal(boolean v) {
@@ -40,21 +44,21 @@ public abstract class MixinServerPlayerEntity extends PlayerEntity implements Pl
 
 	@Override
 	public void immersivecursedness$fakeWorld(World world) {
-		unFakedWorld = this.world;
-		this.world = world;
+		unFakedWorld = this.getWorld();
+		this.setWorld(world);
 	}
 
 	@Override
 	public void immersivecursedness$deFakeWorld() {
 		if (unFakedWorld != null) {
-			this.world = unFakedWorld;
+			setWorld(unFakedWorld);
 			unFakedWorld = null;
 		}
 	}
 
 	@Override
 	public ServerWorld immersivecursedness$getUnfakedWorld() {
-		if (unFakedWorld != null) return (ServerWorld)unFakedWorld;
+		if (unFakedWorld != null) return (ServerWorld) unFakedWorld;
 		return (ServerWorld) getWorld();
 	}
 
@@ -77,10 +81,17 @@ public abstract class MixinServerPlayerEntity extends PlayerEntity implements Pl
 	@Override
 	public void immersivecursedness$setEnabled(boolean v) {
 		enabled = v;
+
 	}
 
 	@Override
 	public boolean immersivecursedness$getEnabled() {
 		return enabled;
+	}
+
+	@Override
+	public void handleGetMaxNetherPortalTime(CallbackInfoReturnable<Integer> cir) {
+		if (enabled)
+			cir.setReturnValue(1);
 	}
 }

--- a/src/main/java/nl/theepicblock/immersive_cursedness/mixin/NetherPortalBlockMixin.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/mixin/NetherPortalBlockMixin.java
@@ -1,0 +1,22 @@
+package nl.theepicblock.immersive_cursedness.mixin;
+
+import net.minecraft.block.NetherPortalBlock;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.world.ServerWorld;
+import nl.theepicblock.immersive_cursedness.PlayerInterface;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(NetherPortalBlock.class)
+public class NetherPortalBlockMixin {
+	@Inject(method = "getPortalDelay", at = @At("HEAD"), cancellable = true)
+	private void getPortalDelay(ServerWorld world, Entity entity, CallbackInfoReturnable<Integer> cir) {
+		if (!(entity instanceof PlayerInterface))
+			return;
+
+		if (((PlayerInterface)entity).immersivecursedness$getEnabled())
+			cir.setReturnValue(1);
+	}
+}

--- a/src/main/java/nl/theepicblock/immersive_cursedness/mixin/PortalForcerMixin.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/mixin/PortalForcerMixin.java
@@ -3,7 +3,7 @@ package nl.theepicblock.immersive_cursedness.mixin;
 import net.minecraft.block.BlockState;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.PortalForcer;
+import net.minecraft.world.dimension.PortalForcer;
 import nl.theepicblock.immersive_cursedness.ImmersiveCursedness;
 import nl.theepicblock.immersive_cursedness.PortalManager;
 import nl.theepicblock.immersive_cursedness.Util;
@@ -17,8 +17,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 public class PortalForcerMixin {
 	@Shadow @Final private ServerWorld world;
 
-	@SuppressWarnings("UnresolvedMixinReference")
-	@Redirect(method = "method_30480", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;getBlockState(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/block/BlockState;"))
+	@Redirect(method = "method_61028", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;getBlockState(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/block/BlockState;"))
 	public BlockState lambdaMixin(ServerWorld world, BlockPos p) {
 		if (PortalManager.portalForcerMixinActivate &&
 				Thread.currentThread() == ImmersiveCursedness.cursednessThread) {

--- a/src/main/java/nl/theepicblock/immersive_cursedness/mixin/ServerChunkManagerInvoker.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/mixin/ServerChunkManagerInvoker.java
@@ -1,7 +1,6 @@
 package nl.theepicblock.immersive_cursedness.mixin;
 
-import com.mojang.datafixers.util.Either;
-import net.minecraft.server.world.ChunkHolder;
+import net.minecraft.server.world.OptionalChunk;
 import net.minecraft.server.world.ServerChunkManager;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkStatus;
@@ -13,5 +12,5 @@ import java.util.concurrent.CompletableFuture;
 @Mixin(ServerChunkManager.class)
 public interface ServerChunkManagerInvoker {
     @Invoker("getChunkFuture")
-    CompletableFuture<Either<Chunk, ChunkHolder.Unloaded>> ic$callGetChunkFuture(int chunkX, int chunkZ, ChunkStatus leastStatus, boolean create);
+    CompletableFuture<OptionalChunk<Chunk>> ic$callGetChunkFuture(int chunkX, int chunkZ, ChunkStatus leastStatus, boolean create);
 }

--- a/src/main/java/nl/theepicblock/immersive_cursedness/mixin/interdimensionalpackets/InventoryDistanceMixin.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/mixin/interdimensionalpackets/InventoryDistanceMixin.java
@@ -1,12 +1,10 @@
 package nl.theepicblock.immersive_cursedness.mixin.interdimensionalpackets;
 
-import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.*;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Clearable;
-import net.minecraft.util.math.BlockPos;
 import nl.theepicblock.immersive_cursedness.PlayerInterface;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -15,8 +13,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Inventory.class)
 public interface InventoryDistanceMixin extends Clearable {
-	@Inject(method = "canPlayerUse(Lnet/minecraft/block/entity/BlockEntity;Lnet/minecraft/entity/player/PlayerEntity;I)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;squaredDistanceTo(DDD)D"), cancellable = true)
-	private static void playerUseRedirect(BlockEntity blockEntity, PlayerEntity player, int range, CallbackInfoReturnable<Boolean> cir) {
+	@Inject(method = "canPlayerUse(Lnet/minecraft/block/entity/BlockEntity;Lnet/minecraft/entity/player/PlayerEntity;F)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;canInteractWithBlockAt(Lnet/minecraft/util/math/BlockPos;D)Z"), cancellable = true)
+	private static void playerUseRedirect(BlockEntity blockEntity, PlayerEntity player, float range, CallbackInfoReturnable<Boolean> cir) {
 		if (((PlayerInterface)player).immersivecursedness$getUnfakedWorld() != blockEntity.getWorld()) {
 			if (player instanceof ServerPlayerEntity) {
 				cir.setReturnValue(PlayerInterface.isCloseToPortal((ServerPlayerEntity)player));

--- a/src/main/java/nl/theepicblock/immersive_cursedness/mixin/interdimensionalpackets/InventoryDistanceMixin.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/mixin/interdimensionalpackets/InventoryDistanceMixin.java
@@ -1,12 +1,11 @@
 package nl.theepicblock.immersive_cursedness.mixin.interdimensionalpackets;
 
 import net.minecraft.block.BlockState;
-import net.minecraft.block.entity.BlockEntityType;
-import net.minecraft.block.entity.BrewingStandBlockEntity;
-import net.minecraft.block.entity.LockableContainerBlockEntity;
-import net.minecraft.block.entity.LootableContainerBlockEntity;
+import net.minecraft.block.entity.*;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.Inventory;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Clearable;
 import net.minecraft.util.math.BlockPos;
 import nl.theepicblock.immersive_cursedness.PlayerInterface;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,15 +13,11 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin({LootableContainerBlockEntity.class, BrewingStandBlockEntity.class})
-public abstract class InventoryDistanceMixin extends LockableContainerBlockEntity {
-	protected InventoryDistanceMixin(BlockEntityType<?> blockEntityType, BlockPos blockPos, BlockState blockState) {
-		super(blockEntityType, blockPos, blockState);
-	}
-
-	@Inject(method = "canPlayerUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;squaredDistanceTo(DDD)D"), cancellable = true)
-	public void playerUseRedirect(PlayerEntity player, CallbackInfoReturnable<Boolean> cir) {
-		if (((PlayerInterface)player).immersivecursedness$getUnfakedWorld() != this.world) {
+@Mixin(Inventory.class)
+public interface InventoryDistanceMixin extends Clearable {
+	@Inject(method = "canPlayerUse(Lnet/minecraft/block/entity/BlockEntity;Lnet/minecraft/entity/player/PlayerEntity;I)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;squaredDistanceTo(DDD)D"), cancellable = true)
+	private static void playerUseRedirect(BlockEntity blockEntity, PlayerEntity player, int range, CallbackInfoReturnable<Boolean> cir) {
+		if (((PlayerInterface)player).immersivecursedness$getUnfakedWorld() != blockEntity.getWorld()) {
 			if (player instanceof ServerPlayerEntity) {
 				cir.setReturnValue(PlayerInterface.isCloseToPortal((ServerPlayerEntity)player));
 			}

--- a/src/main/java/nl/theepicblock/immersive_cursedness/mixin/interdimensionalpackets/MixinInteractionManager.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/mixin/interdimensionalpackets/MixinInteractionManager.java
@@ -33,13 +33,13 @@ public class MixinInteractionManager {
 			if (manager == null) return;
 			BlockPos z = manager.transform(pos);
 			if (z == null) {
-				this.world = player.getWorld();
+				this.world = player.getServerWorld();
 			} else {
 				((BlockPos.Mutable)pos).set(z.getX(), z.getY(), z.getZ());
 				this.world = Util.getDestination(player);
 			}
 		} else {
-			this.world = player.getWorld();
+			this.world = player.getServerWorld();
 		}
 	}
 }

--- a/src/main/java/nl/theepicblock/immersive_cursedness/objects/AsyncWorldView.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/objects/AsyncWorldView.java
@@ -3,17 +3,15 @@ package nl.theepicblock.immersive_cursedness.objects;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.server.world.OptionalChunk;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
-import net.minecraft.world.BlockView;
-import net.minecraft.world.WorldView;
 import net.minecraft.world.chunk.Chunk;
 import nl.theepicblock.immersive_cursedness.Util;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 public class AsyncWorldView {
 	private final Map<ChunkPos,Chunk> chunkCache = new HashMap<>();
@@ -45,9 +43,9 @@ public class AsyncWorldView {
 	public Chunk getChunk(ChunkPos chunkPos) {
 		Chunk chunk = chunkCache.get(chunkPos);
 		if (chunk == null) {
-			Optional<Chunk> chunkO = Util.getChunkAsync(world, chunkPos.x, chunkPos.z);
+			OptionalChunk<Chunk> chunkO = Util.getChunkAsync(world, chunkPos.x, chunkPos.z);
 			if (chunkO.isPresent()) {
-				chunk = chunkO.get();
+				chunk = chunkO.orElseThrow(NullPointerException::new);
 				chunkCache.put(chunkPos, chunk);
 			} else {
 				return null;

--- a/src/main/java/nl/theepicblock/immersive_cursedness/objects/AsyncWorldView.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/objects/AsyncWorldView.java
@@ -2,6 +2,7 @@ package nl.theepicblock.immersive_cursedness.objects;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;

--- a/src/main/java/nl/theepicblock/immersive_cursedness/objects/AsyncWorldView.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/objects/AsyncWorldView.java
@@ -31,6 +31,13 @@ public class AsyncWorldView {
 		return chunk.getBlockState(pos);
 	}
 
+	public BlockEntity getBlockEntity(BlockPos pos) {
+		Chunk chunk = getChunk(pos);
+		if (chunk == null) return null;
+
+		return chunk.getBlockEntity(pos);
+	}
+
 	public Chunk getChunk(BlockPos p) {
 		return getChunk(new ChunkPos(p));
 	}

--- a/src/main/java/nl/theepicblock/immersive_cursedness/objects/BlockUpdateMap.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/objects/BlockUpdateMap.java
@@ -39,7 +39,7 @@ public class BlockUpdateMap extends Long2ObjectOpenHashMap<Short2ObjectMap<Block
                 buf.writeVarLong(((long)Block.getRawIdFromState(entry.getValue()) << 12 | entry.getShortKey()));
             }
 
-            ChunkDeltaUpdateS2CPacket packet = new ChunkDeltaUpdateS2CPacket(buf);
+            ChunkDeltaUpdateS2CPacket packet = ChunkDeltaUpdateS2CPacket.CODEC.decode(buf);
             player.networkHandler.sendPacket(packet);
         });
     }

--- a/src/main/java/nl/theepicblock/immersive_cursedness/objects/BlockUpdateMap.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/objects/BlockUpdateMap.java
@@ -32,7 +32,7 @@ public class BlockUpdateMap extends Long2ObjectOpenHashMap<Short2ObjectMap<Block
         this.forEach((chunkSection, chunkContents) -> {
             var buf = PacketByteBufs.create();
             buf.writeLong(chunkSection);
-            buf.writeBoolean(false);
+            //buf.writeBoolean(false);
             buf.writeVarInt(chunkContents.size());
 
             for (Short2ObjectMap.Entry<BlockState> entry : chunkContents.short2ObjectEntrySet()) {

--- a/src/main/java/nl/theepicblock/immersive_cursedness/objects/DummyEntity.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/objects/DummyEntity.java
@@ -1,27 +1,33 @@
 package nl.theepicblock.immersive_cursedness.objects;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.NetherPortalBlock;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityDimensions;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.data.DataTracker;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.listener.ClientPlayPacketListener;
 import net.minecraft.network.packet.Packet;
+import net.minecraft.network.packet.s2c.play.PositionFlag;
+import net.minecraft.server.network.EntityTrackerEntry;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.state.property.Properties;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.Heightmap;
 import net.minecraft.world.BlockLocating;
 import net.minecraft.world.TeleportTarget;
 import net.minecraft.world.World;
 import net.minecraft.world.border.WorldBorder;
 import net.minecraft.world.dimension.NetherPortal;
 import net.minecraft.world.dimension.DimensionType;
-import nl.theepicblock.immersive_cursedness.Util;
 
 import java.util.Optional;
+
+import static net.minecraft.block.NetherPortalBlock.AXIS;
 
 @SuppressWarnings("EntityConstructor")
 public class DummyEntity extends Entity {
@@ -31,8 +37,13 @@ public class DummyEntity extends Entity {
     }
 
     @Override
-    protected void initDataTracker() {
+    protected void initDataTracker(DataTracker.Builder builder) {
 
+    }
+
+    @Override
+    public boolean damage(ServerWorld world, DamageSource source, float amount) {
+        return false;
     }
 
     @Override
@@ -46,7 +57,7 @@ public class DummyEntity extends Entity {
     }
 
     @Override
-    public Packet<ClientPlayPacketListener> createSpawnPacket() {
+    public Packet<ClientPlayPacketListener> createSpawnPacket(EntityTrackerEntry entityTrackerEntry) {
         return null;
     }
 
@@ -56,37 +67,90 @@ public class DummyEntity extends Entity {
     }
 
     public TeleportTarget getTeleportTargetB(ServerWorld destination) {
-        this.setInNetherPortal(this.getBlockPos());
+        this.tryUsePortal((NetherPortalBlock) Blocks.NETHER_PORTAL, this.getBlockPos());
         return this.getTeleportTarget(destination);
     }
 
-    @Override
     protected TeleportTarget getTeleportTarget(ServerWorld destination) {
-        boolean bl3 = destination.getRegistryKey() == World.NETHER;
-        if (this.getWorld().getRegistryKey() != World.NETHER && !bl3) {
+	    if (destination == null) {
             return null;
         } else {
-            double coordinateScale = DimensionType.getCoordinateScaleFactor(this.getWorld().getDimension(), destination.getDimension());
-            BlockPos blockPos3 = new BlockPos(MathHelper.floor(this.getX() * coordinateScale), MathHelper.floor(this.getY()), MathHelper.floor(this.getZ() * coordinateScale));
+            boolean bl = destination.getRegistryKey() == World.NETHER;
             WorldBorder worldBorder = destination.getWorldBorder();
-            Optional<BlockLocating.Rectangle> portalPosA = this.getPortalRect(destination, blockPos3, bl3, worldBorder);
-            if (portalPosA.isPresent()) {
-                BlockState blockState = Util.getBlockAsync((ServerWorld)this.getWorld(), this.lastNetherPortalPosition);
-                Direction.Axis axis2;
-                Vec3d vec3d2;
-                if (blockState.contains(Properties.HORIZONTAL_AXIS)) {
-                    axis2 = blockState.get(Properties.HORIZONTAL_AXIS);
-                    BlockLocating.Rectangle portalPos = BlockLocating.getLargestRectangle(this.lastNetherPortalPosition, axis2, 21, Direction.Axis.Y, 21, (blockPos) -> Util.getBlockAsync((ServerWorld)this.getWorld(), blockPos) == blockState);
-                    vec3d2 = this.positionInPortal(axis2, portalPos);
-                } else {
-                    return null;
-                }
+            double d = DimensionType.getCoordinateScaleFactor(getWorld().getDimension(), destination.getDimension());
+            BlockPos blockPos = worldBorder.clampFloored(getX() * d, getY(), getZ() * d);
+            return this.getOrCreateExitPortalTarget(destination, this, getBlockPos(), blockPos, bl, worldBorder);
+        }
+    }
 
-                var entity = (Entity) (Object) this;
-                return NetherPortal.getNetherTeleportTarget(destination, portalPosA.get(), axis2, vec3d2, entity, this.getVelocity(), this.getYaw(), this.getPitch());
-            } else {
+    private TeleportTarget getOrCreateExitPortalTarget(
+            ServerWorld world, Entity entity, BlockPos pos, BlockPos scaledPos, boolean inNether, WorldBorder worldBorder
+    ) {
+        Optional<BlockPos> optional = world.getPortalForcer().getPortalPos(scaledPos, inNether, worldBorder);
+        BlockLocating.Rectangle rectangle;
+        TeleportTarget.PostDimensionTransition postDimensionTransition;
+        if (optional.isPresent()) {
+            BlockPos blockPos = optional.get();
+            BlockState blockState = world.getBlockState(blockPos);
+            rectangle = BlockLocating.getLargestRectangle(
+                    blockPos, blockState.get(Properties.HORIZONTAL_AXIS), 21, Direction.Axis.Y, 21, posx -> world.getBlockState(posx) == blockState
+            );
+            postDimensionTransition = TeleportTarget.SEND_TRAVEL_THROUGH_PORTAL_PACKET.then(entityx -> entityx.addPortalChunkTicketAt(blockPos));
+        } else {
+            Direction.Axis axis = entity.getWorld().getBlockState(pos).getOrEmpty(AXIS).orElse(Direction.Axis.X);
+            Optional<BlockLocating.Rectangle> optional2 = world.getPortalForcer().createPortal(scaledPos, axis);
+            if (optional2.isEmpty()) {
                 return null;
             }
+
+            rectangle = optional2.get();
+            postDimensionTransition = TeleportTarget.SEND_TRAVEL_THROUGH_PORTAL_PACKET.then(TeleportTarget.ADD_PORTAL_CHUNK_TICKET);
         }
+
+        return getExitPortalTarget(entity, pos, rectangle, world, postDimensionTransition);
+    }
+
+    private static TeleportTarget getExitPortalTarget(
+            Entity entity, BlockPos pos, BlockLocating.Rectangle exitPortalRectangle, ServerWorld world, TeleportTarget.PostDimensionTransition postDimensionTransition
+    ) {
+        BlockState blockState = entity.getWorld().getBlockState(pos);
+        Direction.Axis axis;
+        Vec3d vec3d;
+        if (blockState.contains(Properties.HORIZONTAL_AXIS)) {
+            axis = blockState.get(Properties.HORIZONTAL_AXIS);
+            BlockLocating.Rectangle rectangle = BlockLocating.getLargestRectangle(
+                    pos, axis, 21, Direction.Axis.Y, 21, posx -> entity.getWorld().getBlockState(posx) == blockState
+            );
+            vec3d = entity.positionInPortal(axis, rectangle);
+        } else {
+            axis = Direction.Axis.X;
+            vec3d = new Vec3d(0.5, 0.0, 0.0);
+        }
+
+        return getExitPortalTarget(world, exitPortalRectangle, axis, vec3d, entity, postDimensionTransition);
+    }
+
+    private static TeleportTarget getExitPortalTarget(
+            ServerWorld world,
+            BlockLocating.Rectangle exitPortalRectangle,
+            Direction.Axis axis,
+            Vec3d positionInPortal,
+            Entity entity,
+            TeleportTarget.PostDimensionTransition postDimensionTransition
+    ) {
+        BlockPos blockPos = exitPortalRectangle.lowerLeft;
+        BlockState blockState = world.getBlockState(blockPos);
+        Direction.Axis axis2 = blockState.getOrEmpty(Properties.HORIZONTAL_AXIS).orElse(Direction.Axis.X);
+        double d = exitPortalRectangle.width;
+        double e = exitPortalRectangle.height;
+        EntityDimensions entityDimensions = entity.getDimensions(entity.getPose());
+        int i = axis == axis2 ? 0 : 90;
+        double f = entityDimensions.width() / 2.0 + (d - entityDimensions.width()) * positionInPortal.getX();
+        double g = (e - entityDimensions.height()) * positionInPortal.getY();
+        double h = 0.5 + positionInPortal.getZ();
+        boolean bl = axis2 == Direction.Axis.X;
+        Vec3d vec3d = new Vec3d(blockPos.getX() + (bl ? f : h), blockPos.getY() + g, blockPos.getZ() + (bl ? h : f));
+        Vec3d vec3d2 = NetherPortal.findOpenPosition(vec3d, world, entity, entityDimensions);
+        return new TeleportTarget(world, vec3d2, Vec3d.ZERO, i, 0.0F, PositionFlag.combine(PositionFlag.DELTA, PositionFlag.ROT), postDimensionTransition);
     }
 }

--- a/src/main/java/nl/theepicblock/immersive_cursedness/objects/FlatStandingRectangle.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/objects/FlatStandingRectangle.java
@@ -1,12 +1,10 @@
 package nl.theepicblock.immersive_cursedness.objects;
 
-import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.HeightLimitView;
-import net.minecraft.world.World;
 import nl.theepicblock.immersive_cursedness.Util;
 
 import java.util.function.Consumer;
@@ -51,12 +49,12 @@ public class FlatStandingRectangle {
 
     public BlockPos getBottomLeftBlockClamped(Vec3d center, int limit, HeightLimitView world) {
         double centerP = Util.get(center, Util.rotate(axis));
-        return createBlockPos(clamp(bottom, world.getBottomY(), world.getTopY()), clamp(left,centerP-limit,centerP+limit));
+        return createBlockPos(clamp(bottom, world.getBottomY(), world.getTopYInclusive()), clamp(left,centerP-limit,centerP+limit));
     }
 
     public BlockPos getTopRightBlockClamped(Vec3d center, int limit, HeightLimitView world) {
         double centerP = Util.get(center, Util.rotate(axis));
-        return createBlockPos(clamp(top-1, world.getBottomY(), world.getTopY()), clamp(right-1,centerP-limit,centerP+limit));
+        return createBlockPos(clamp(top-1, world.getBottomY(), world.getTopYInclusive()), clamp(right-1,centerP-limit,centerP+limit));
     }
 
     public FlatStandingRectangle expand(int i, Vec3d source) {

--- a/src/main/java/nl/theepicblock/immersive_cursedness/objects/TransformProfile.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/objects/TransformProfile.java
@@ -133,4 +133,9 @@ public class TransformProfile {
         BlockState state = world.getBlock(transformedPos);
         return this.rotateState(state);
     }
+
+    public BlockEntity transformAndGetFromWorldBlockEntity(BlockPos pos, AsyncWorldView world) {
+        BlockPos transformedPos = this.transform(pos);
+        return world.getBlockEntity(transformedPos);
+    }
 }

--- a/src/main/java/nl/theepicblock/immersive_cursedness/objects/TransformProfile.java
+++ b/src/main/java/nl/theepicblock/immersive_cursedness/objects/TransformProfile.java
@@ -2,6 +2,7 @@ package nl.theepicblock.immersive_cursedness.objects;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockPos;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
   "depends": {
     "fabricloader": ">=0.7.4",
     "fabric": "*",
-    "minecraft": "1.20.x",
+    "minecraft": "1.21.x",
     "java": ">=16"
   },
   "suggests": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
   "depends": {
     "fabricloader": ">=0.7.4",
     "fabric": "*",
-    "minecraft": "1.19.x",
+    "minecraft": "1.20.x",
     "java": ">=16"
   },
   "suggests": {

--- a/src/main/resources/immersive-cursedness.mixins.json
+++ b/src/main/resources/immersive-cursedness.mixins.json
@@ -7,6 +7,7 @@
     "EntityPositionS2CPacketAccessor",
     "MixinPlayerEntity",
     "MixinServerPlayerEntity",
+    "NetherPortalBlockMixin",
     "PortalForcerMixin",
     "ServerChunkManagerInvoker",
     "interdimensionalpackets.InventoryDistanceMixin",


### PR DESCRIPTION
I probably shouldn't have made both in a single pull request but hey.

The way I'm supporting block entities appears to work and hasn't given me any issues so far, but it could probably be made more memory efficient in at least some way.

There shouldn't be any issues that are too bad in this, seeing as I've been using it for a little bit and it seems to be working.

---

The 1.20.1 version of this is only very lightly tested, but it appears to work fine?

If anyone finds something wrong with this, feel free to put a comment either here or on my fork's issues page!